### PR TITLE
simple-draggable 1.1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.swp
+*.swo
+*~
+*.log
+node_modules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,8 @@ Contributions are more than welcome!
 
 Thanks! :sweat_smile:
 
+
+
 [1]: https://github.com/IonicaBizau/simple-draggable.js/issues
 
 [2]: https://github.com/IonicaBizau/code-style

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,0 +1,16 @@
+## Documentation
+
+You can see below the API reference of this module.
+
+### `SimpleDraggable(selector, options)`
+Initializes the draggable state.
+
+#### Params
+- **String** `selector`: The element query selector.
+- **Object** `options`: An object containing:
+ - `onStart` (Function): A function to run on drag start.
+ - `onStop` (Function): A function to run on drag stop.
+ - `onDrag` (Function): A function to run on drag move.
+ - `onlyX` (Boolean): Drag the element only on the X axis.
+ - `onlyY` (Boolean): Drag the element only on the Y axis.
+

--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
+
 # simple-draggable [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/simple-draggable.svg)](https://www.npmjs.com/package/simple-draggable) [![Downloads](https://img.shields.io/npm/dt/simple-draggable.svg)](https://www.npmjs.com/package/simple-draggable) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > A tiny library to make elements draggable.
 
-## Installation
+## :cloud: Installation
 
 ```sh
 $ npm i --save simple-draggable
 ```
 
-## Example
+
+## :clipboard: Example
+
+
 
 ```js
 SimpleDraggable(".cursor", {
@@ -26,7 +30,8 @@ SimpleDraggable(".cursor", {
 });
 ```
 
-## Documentation
+## :memo: Documentation
+
 
 ### `SimpleDraggable(selector, options)`
 Initializes the draggable state.
@@ -40,13 +45,13 @@ Initializes the draggable state.
  - `onlyX` (Boolean): Drag the element only on the X axis.
  - `onlyY` (Boolean): Drag the element only on the Y axis.
 
-## How to contribute
+
+
+## :yum: How to contribute
 Have an idea? Found a bug? See [how to contribute][contributing].
 
-## Where is this library used?
-If you are using this library in one of your projects, add it in this list. :sparkles:
 
-## License
+## :scroll: License
 
 [MIT][license] © [Ionică Bizău][website]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-draggable",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A tiny library to make elements draggable.",
   "main": "lib/index.js",
   "scripts": {
@@ -19,5 +19,16 @@
   "bugs": {
     "url": "https://github.com/IonicaBizau/simple-draggable.js/issues"
   },
-  "homepage": "https://github.com/IonicaBizau/simple-draggable.js#readme"
+  "homepage": "https://github.com/IonicaBizau/simple-draggable.js#readme",
+  "files": [
+    "bin/",
+    "app/",
+    "lib/",
+    "dist/",
+    "src/",
+    "resources/",
+    "menu/",
+    "cli.js",
+    "index.js"
+  ]
 }


### PR DESCRIPTION
 - Updated the README.md following the new template. :memo:
 - Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.